### PR TITLE
Feat: 주문 등록, 취소와 계정 탈퇴 기능 추가

### DIFF
--- a/src/main/java/com/ono/omg/controller/AccountController.java
+++ b/src/main/java/com/ono/omg/controller/AccountController.java
@@ -1,24 +1,19 @@
 package com.ono.omg.controller;
 
 import com.ono.omg.dto.common.ResponseDto;
+import com.ono.omg.security.user.UserDetailsImpl;
 import com.ono.omg.service.AccountService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.ui.Model;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
 
 import javax.servlet.http.HttpServletResponse;
 import javax.validation.Valid;
 
 import static com.ono.omg.dto.request.AccountRequestDto.AccountLoginRequestDto;
 import static com.ono.omg.dto.request.AccountRequestDto.AccountRegisterRequestDto;
-import static com.ono.omg.dto.response.AccountResponseDto.AccountLoginResponseDto;
-import static com.ono.omg.dto.response.AccountResponseDto.AccountRegisterResponseDto;
+import static com.ono.omg.dto.response.AccountResponseDto.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -34,9 +29,6 @@ public class AccountController {
      */
     @PostMapping("/signup")
     public ResponseDto<AccountRegisterResponseDto> registerAccount(@RequestBody @Valid AccountRegisterRequestDto accountRequestDto) {
-//        logger.info("INFO Level 테스트");
-//        logger.warn("Warn Level 테스트");
-//        log.info("AccountController.registerAccount");
         System.out.println("accountRequestDto = " + accountRequestDto);
         return ResponseDto.success(accountService.signup(accountRequestDto));
     }
@@ -47,5 +39,13 @@ public class AccountController {
     @PostMapping("/login")
     public ResponseDto<AccountLoginResponseDto> login(@RequestBody AccountLoginRequestDto accountLoginRequestDto, HttpServletResponse response) {
         return ResponseDto.success(accountService.login(accountLoginRequestDto, response));
+    }
+
+    /**
+     * 회원 탈퇴 (API 명세 추가 예정)
+     */
+    @DeleteMapping("/unregister")
+    public ResponseDto<UnregisterUser> eraseAccount(@AuthenticationPrincipal UserDetailsImpl userDetails) {
+        return ResponseDto.success(accountService.unregister(userDetails.getAccount()));
     }
 }

--- a/src/main/java/com/ono/omg/controller/OrderController.java
+++ b/src/main/java/com/ono/omg/controller/OrderController.java
@@ -1,15 +1,21 @@
 package com.ono.omg.controller;
 
+import com.ono.omg.domain.Account;
 import com.ono.omg.dto.common.ResponseDto;
 import com.ono.omg.security.user.UserDetailsImpl;
 import com.ono.omg.service.OrderService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.concurrent.TimeUnit;
 
 import static com.ono.omg.dto.response.OrderResponseDto.CreatedOrdersResponseDto;
 
@@ -22,10 +28,32 @@ public class OrderController {
     // 특정 사용자의 주문 목록 조회
 
     private final OrderService orderService;
+    private final RedissonClient redissonClient;
 
+    /**
+     * 리팩토링 정상작동 OK
+     * 나중에 토큰 구현되면 Account account만 AuthenticationPrincipal로 변경하면 OK
+     */
     @PostMapping("/{productId}/confirm")
-    public ResponseDto<CreatedOrdersResponseDto> CreatedOrder(@PathVariable Long productId,
-                                                              @AuthenticationPrincipal UserDetailsImpl userDetails) {
-        return ResponseDto.success(orderService.productOrder(productId, userDetails.getAccount()));
+    public ResponseDto<CreatedOrdersResponseDto> CreatedOrder(@PathVariable Long productId, Account account) {
+
+        RLock lock = redissonClient.getLock(productId.toString());
+        CreatedOrdersResponseDto responseDto;
+        try {
+            boolean available = lock.tryLock(20, 1, TimeUnit.SECONDS);
+
+            if (!available) {
+                /**
+                 * 별도의 Custom Exception으로 처리
+                 */
+                return null;
+            }
+            responseDto = orderService.productOrder(productId, account);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        } finally {
+            lock.unlock();
+        }
+        return ResponseDto.success(responseDto);
     }
 }

--- a/src/main/java/com/ono/omg/controller/OrderController.java
+++ b/src/main/java/com/ono/omg/controller/OrderController.java
@@ -2,7 +2,6 @@ package com.ono.omg.controller;
 
 import com.ono.omg.domain.Account;
 import com.ono.omg.dto.common.ResponseDto;
-import com.ono.omg.dto.response.OrderResponseDto;
 import com.ono.omg.security.user.UserDetailsImpl;
 import com.ono.omg.service.OrderService;
 import lombok.RequiredArgsConstructor;
@@ -17,8 +16,8 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.util.concurrent.TimeUnit;
 
-import static com.ono.omg.dto.response.OrderResponseDto.*;
 import static com.ono.omg.dto.response.OrderResponseDto.CreatedOrdersResponseDto;
+import static com.ono.omg.dto.response.OrderResponseDto.cancelOrderResponseDto;
 
 @RestController
 @Slf4j
@@ -34,11 +33,12 @@ public class OrderController {
     /**
      * 리팩토링 정상작동 OK
      * 나중에 토큰 구현되면 Account account만 AuthenticationPrincipal로 변경하면 OK
+     * 만약 Postman으로 테스트 시 주석 번갈아가면서 테스트
      */
     @PostMapping("/{productId}/confirm")
     public ResponseDto<CreatedOrdersResponseDto> CreatedOrder(@PathVariable Long productId,
-//                                                              Account account
-                                                              @AuthenticationPrincipal UserDetailsImpl account
+                                                              Account account
+//                                                              @AuthenticationPrincipal UserDetailsImpl account
                                                               ) {
 
         RLock lock = redissonClient.getLock(productId.toString());
@@ -52,7 +52,8 @@ public class OrderController {
                  */
                 return null;
             }
-            responseDto = orderService.productOrder(productId, account.getAccount());
+            responseDto = orderService.productOrder(productId, account);
+//            responseDto = orderService.productOrder(productId, account.getAccount());
         } catch (InterruptedException e) {
             throw new RuntimeException(e);
         } finally {

--- a/src/main/java/com/ono/omg/controller/ProductController.java
+++ b/src/main/java/com/ono/omg/controller/ProductController.java
@@ -56,10 +56,10 @@ public class ProductController {
         return new ResponseEntity<>(ResponseDto.success(productService.searchProduct(productId)), HttpStatus.OK);
     }
 
-    @PostConstruct
-    public void init() {
-        for (int i = 0; i < 100; i++) {
-            productRepository.save(new Product("피카츄" + i, 1000 + i, "포켓몬", "초고속 배송", 15 + i, 1L));
-        }
-    }
+//    @PostConstruct
+//    public void init() {
+//        for (int i = 0; i < 100; i++) {
+//            productRepository.save(new Product("피카츄" + i, 1000 + i, "포켓몬", "초고속 배송", 15 + i, 1L));
+//        }
+//    }
 }

--- a/src/main/java/com/ono/omg/controller/ProductController.java
+++ b/src/main/java/com/ono/omg/controller/ProductController.java
@@ -55,11 +55,4 @@ public class ProductController {
     public ResponseEntity<ResponseDto<ProductResDto>> searchProduct(@PathVariable Long productId) {
         return new ResponseEntity<>(ResponseDto.success(productService.searchProduct(productId)), HttpStatus.OK);
     }
-
-//    @PostConstruct
-//    public void init() {
-//        for (int i = 0; i < 100; i++) {
-//            productRepository.save(new Product("피카츄" + i, 1000 + i, "포켓몬", "초고속 배송", 15 + i, 1L));
-//        }
-//    }
 }

--- a/src/main/java/com/ono/omg/controller/ProductController.java
+++ b/src/main/java/com/ono/omg/controller/ProductController.java
@@ -1,10 +1,8 @@
 package com.ono.omg.controller;
 
-import com.ono.omg.domain.Product;
-import com.ono.omg.dto.response.ProductResponseDto;
+import com.ono.omg.dto.common.ResponseDto;
 import com.ono.omg.dto.request.ProductReqDto;
 import com.ono.omg.dto.response.ProductResDto;
-import com.ono.omg.dto.common.ResponseDto;
 import com.ono.omg.repository.product.ProductRepository;
 import com.ono.omg.security.user.UserDetailsImpl;
 import com.ono.omg.service.ProductService;
@@ -14,10 +12,9 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
-import javax.annotation.PostConstruct;
 import java.util.List;
 
-import static com.ono.omg.dto.response.ProductResponseDto.*;
+import static com.ono.omg.dto.response.ProductResponseDto.MainPageResponseDto;
 
 @RestController
 @RequiredArgsConstructor

--- a/src/main/java/com/ono/omg/domain/Account.java
+++ b/src/main/java/com/ono/omg/domain/Account.java
@@ -35,8 +35,7 @@ public class Account extends BaseEntity {
         this.password = accountRegisterRequestDto.getPassword();
     }
 
-    public Account(Long id, AccountType accountType, String username, String password, DeletedType deletedType) {
-        this.id = id;
+    public Account(AccountType accountType, String username, String password, DeletedType deletedType) {
         this.accountType = accountType;
         this.username = username;
         this.password = password;

--- a/src/main/java/com/ono/omg/domain/Account.java
+++ b/src/main/java/com/ono/omg/domain/Account.java
@@ -1,7 +1,6 @@
 package com.ono.omg.domain;
 
 import com.ono.omg.domain.base.BaseEntity;
-import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;

--- a/src/main/java/com/ono/omg/domain/Order.java
+++ b/src/main/java/com/ono/omg/domain/Order.java
@@ -29,13 +29,25 @@ public class Order extends BaseEntity {
     @Column(name = "total_price")
     private Integer totalPrice;
 
-    private String isDeleted;
+    private String isDeleted = "N";
 
 
     public Order(Account account, Product product, Integer totalPrice) {
+        decrease(product);
         this.account = account;
         this.product = product;
         this.totalPrice = totalPrice;
-        isDeleted = "N";
+
+    }
+
+    public void decrease(Product product) {
+        int productStock = product.getStock();
+        if (productStock - 1 < 0) {
+            /**
+             * CustomException 처리로 변경
+             */
+            throw new RuntimeException("재고부족으로 인해 주문이 불가합니다");
+        }
+        product.decreaseStock(productStock);
     }
 }

--- a/src/main/java/com/ono/omg/domain/Order.java
+++ b/src/main/java/com/ono/omg/domain/Order.java
@@ -1,6 +1,8 @@
 package com.ono.omg.domain;
 
 import com.ono.omg.domain.base.BaseEntity;
+import com.ono.omg.exception.CustomCommonException;
+import com.ono.omg.exception.ErrorCode;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -33,8 +35,7 @@ public class Order extends BaseEntity {
      * isDeleted >> OrderType
      */
     @Enumerated(EnumType.STRING)
-    private String orderType = OrderType.ORDER_OK.getStatus();
-
+    private OrderType orderType = OrderType.ORDER_OK;
 
     public Order(Account account, Product product, Integer totalPrice) {
         decrease(product);
@@ -43,14 +44,21 @@ public class Order extends BaseEntity {
         this.totalPrice = totalPrice;
     }
 
+    /**
+     * 재고 부족 테스트 완료
+     */
     public void decrease(Product product) {
         int productStock = product.getStock();
         if (productStock - 1 < 0) {
-            /**
-             * CustomException 처리로 변경
-             */
-            throw new RuntimeException("재고부족으로 인해 주문이 불가합니다");
+            throw new CustomCommonException(ErrorCode.OUT_OF_STOCK);
         }
         product.decreaseStock(productStock);
+    }
+
+    /**
+     * 주문 취소
+     */
+    public void orderCancel() {
+        this.orderType = OrderType.ORDER_CANCEL;
     }
 }

--- a/src/main/java/com/ono/omg/domain/Order.java
+++ b/src/main/java/com/ono/omg/domain/Order.java
@@ -29,7 +29,11 @@ public class Order extends BaseEntity {
     @Column(name = "total_price")
     private Integer totalPrice;
 
-    private String isDeleted = "N";
+    /**
+     * isDeleted >> OrderType
+     */
+    @Enumerated(EnumType.STRING)
+    private String orderType = OrderType.ORDER_OK.getStatus();
 
 
     public Order(Account account, Product product, Integer totalPrice) {
@@ -37,7 +41,6 @@ public class Order extends BaseEntity {
         this.account = account;
         this.product = product;
         this.totalPrice = totalPrice;
-
     }
 
     public void decrease(Product product) {

--- a/src/main/java/com/ono/omg/domain/OrderType.java
+++ b/src/main/java/com/ono/omg/domain/OrderType.java
@@ -2,6 +2,7 @@ package com.ono.omg.domain;
 
 public enum OrderType {
 
+    ORDER_CANCEL("주문 취소"),
     ORDER_OK("주문 완료"),
     DELIVERY_READY("상품 준비"),
     DELIVERY_START("배송 시작"),

--- a/src/main/java/com/ono/omg/domain/OrderType.java
+++ b/src/main/java/com/ono/omg/domain/OrderType.java
@@ -1,0 +1,21 @@
+package com.ono.omg.domain;
+
+public enum OrderType {
+
+    ORDER_OK("주문 완료"),
+    DELIVERY_READY("상품 준비"),
+    DELIVERY_START("배송 시작"),
+    RECEIVE_OK("수령 완료");
+
+    private String status;
+
+    private OrderType() {}
+
+    OrderType(String status) {
+        this.status = status;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+}

--- a/src/main/java/com/ono/omg/domain/Product.java
+++ b/src/main/java/com/ono/omg/domain/Product.java
@@ -6,7 +6,6 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
-import org.springframework.transaction.annotation.Transactional;
 
 import javax.persistence.*;
 

--- a/src/main/java/com/ono/omg/domain/Product.java
+++ b/src/main/java/com/ono/omg/domain/Product.java
@@ -6,9 +6,9 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
+import org.springframework.transaction.annotation.Transactional;
 
 import javax.persistence.*;
-import java.util.Random;
 
 @Entity
 @Getter
@@ -101,15 +101,11 @@ public class Product extends BaseEntity {
         this.delivery = productReqDto.getDelivery();
     }
 
-    public void isDeleted() {
-        this.isDeleted = "Y";
+    public void decreaseStock(int productStock) {
+        this.stock = productStock - 1;
     }
 
-    public void decrease() {
-        if (this.stock - 1 < 0) {
-            throw new RuntimeException("재고부족으로 인해 주문이 불가합니다");
-        }
-        this.stock -= 1;
-
+    public void isDeleted() {
+        this.isDeleted = "Y";
     }
 }

--- a/src/main/java/com/ono/omg/dto/response/AccountResponseDto.java
+++ b/src/main/java/com/ono/omg/dto/response/AccountResponseDto.java
@@ -38,14 +38,23 @@ public class AccountResponseDto {
         private LocalDateTime createdAt;
         private LocalDateTime modifiedAt;
 
-//        private String token;
-
         public AccountLoginResponseDto(Account account) {
             this.username = account.getUsername();
             this.accountType = account.getAccountType();
             this.createdAt = account.getCreatedAt();
             this.modifiedAt = account.getModifiedAt();
-//            this.token = accessToken;
+        }
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class UnregisterUser {
+        private String username;
+        private String msg = "그동안 온앤온(ONO) 서비스를 이용해주셔서 감사합니다.";
+
+        public UnregisterUser(String username) {
+            this.username = username;
         }
     }
 }

--- a/src/main/java/com/ono/omg/dto/response/OrderResponseDto.java
+++ b/src/main/java/com/ono/omg/dto/response/OrderResponseDto.java
@@ -6,8 +6,6 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import javax.persistence.Column;
-
 public class OrderResponseDto {
 
     @Getter

--- a/src/main/java/com/ono/omg/dto/response/OrderResponseDto.java
+++ b/src/main/java/com/ono/omg/dto/response/OrderResponseDto.java
@@ -17,6 +17,7 @@ public class OrderResponseDto {
         // order
         private Long orderId;
         private Integer orderTotalPrice;
+//        private String orderStatus;
 
         // account
         private String username;
@@ -26,6 +27,7 @@ public class OrderResponseDto {
         private String category;
         private String delivery;
         private Long seller;
+
 
         @QueryProjection
         public CreatedOrdersResponseDto(Long orderId, Integer orderTotalPrice, String username, String title, String category, String delivery, Long seller) {
@@ -47,5 +49,18 @@ public class OrderResponseDto {
             this.delivery = product.getDelivery();
             this.seller = product.getSellerId();
         }
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class cancelOrderResponseDto {
+        /**
+         * 다중 상품인 경우 아래 두 필드는 List에 별도의 Dto로 담김
+         */
+        private Long productId;
+        private String productName;
+
+        private String orderStatus;
     }
 }

--- a/src/main/java/com/ono/omg/dto/response/OrderResponseDto.java
+++ b/src/main/java/com/ono/omg/dto/response/OrderResponseDto.java
@@ -1,5 +1,6 @@
 package com.ono.omg.dto.response;
 
+import com.ono.omg.domain.Product;
 import com.querydsl.core.annotations.QueryProjection;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -35,6 +36,16 @@ public class OrderResponseDto {
             this.category = category;
             this.delivery = delivery;
             this.seller = seller;
+        }
+
+        public CreatedOrdersResponseDto(Long orderId, Integer orderTotalPrice, String username, Product product) {
+            this.orderId = orderId;
+            this.orderTotalPrice = orderTotalPrice;
+            this.username = username;
+            this.title = product.getTitle();
+            this.category = product.getCategory();
+            this.delivery = product.getDelivery();
+            this.seller = product.getSellerId();
         }
     }
 }

--- a/src/main/java/com/ono/omg/exception/ErrorCode.java
+++ b/src/main/java/com/ono/omg/exception/ErrorCode.java
@@ -12,6 +12,7 @@ public enum ErrorCode {
     DUPLICATE_EMAIL(400, HttpStatus.BAD_REQUEST, "중복된 이메일이 존재합니다."),
     DUPLICATE_USERNAME(400, HttpStatus.BAD_REQUEST, "중복된 닉네임이 존재합니다."),
     NOT_EQUAL_PASSWORD(400, HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다."),
+    UNREGISTER_USER(400, HttpStatus.BAD_REQUEST, "탈퇴한 회원입니다."),
 
     DUPLICATE_PRODUCT(400, HttpStatus.BAD_REQUEST, "중복된 상품이 존재합니다."),
     // 401 UNAUTHORIZED 권한 없음

--- a/src/main/java/com/ono/omg/exception/ErrorCode.java
+++ b/src/main/java/com/ono/omg/exception/ErrorCode.java
@@ -20,10 +20,11 @@ public enum ErrorCode {
     // 403 FORBIDDEN 접근 실패
     FORBIDDEN_USER(403, HttpStatus.FORBIDDEN, "로그인이 필요합니다."),
     INVALID_USER(403, HttpStatus.FORBIDDEN, "올바른 사용자가 아닙니다."),
+    OUT_OF_STOCK(403, HttpStatus.FORBIDDEN, "재고가 없습니다. 판매자에게 문의하세요"),
 
     // 404 NOT_FOUND 존재하지 않음
     USER_NOT_FOUND(404, HttpStatus.NOT_FOUND, "존재하지 않는 사용자입니다."),
-    ROOM_NOT_FOUND(404, HttpStatus.NOT_FOUND, "존재하지 않는 방입니다."),
+    ORDER_NOT_FOUND(404, HttpStatus.NOT_FOUND, "해당 주문이 존재하지 않습니다."),
     NOT_FOUND_PRODUCT(404, HttpStatus.NOT_FOUND, "상품이 존재하지 않습니다."),
     EMAIL_NOT_FOUND(404, HttpStatus.NOT_FOUND, "해당 이메일은 존재하지 않습니다."),
 

--- a/src/main/java/com/ono/omg/redisson/RedissonLockStockFacade.java
+++ b/src/main/java/com/ono/omg/redisson/RedissonLockStockFacade.java
@@ -25,7 +25,7 @@ public class RedissonLockStockFacade {
             if (!available) {
                 return;
             }
-            orderService.testDecrease(key, account);
+            orderService.productOrder(key, account);
         } catch (InterruptedException e) {
             throw new RuntimeException(e);
         } finally {

--- a/src/main/java/com/ono/omg/service/AccountService.java
+++ b/src/main/java/com/ono/omg/service/AccountService.java
@@ -1,6 +1,7 @@
 package com.ono.omg.service;
 
 import com.ono.omg.domain.Account;
+import com.ono.omg.domain.DeletedType;
 import com.ono.omg.domain.RefreshToken;
 import com.ono.omg.exception.CustomCommonException;
 import com.ono.omg.exception.ErrorCode;
@@ -18,10 +19,10 @@ import org.springframework.util.StringUtils;
 
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletResponse;
-
 import java.util.Optional;
 
-import static com.ono.omg.dto.request.AccountRequestDto.*;
+import static com.ono.omg.dto.request.AccountRequestDto.AccountLoginRequestDto;
+import static com.ono.omg.dto.request.AccountRequestDto.AccountRegisterRequestDto;
 import static com.ono.omg.dto.response.AccountResponseDto.*;
 
 @Service
@@ -64,6 +65,13 @@ public class AccountService {
                 () -> new CustomCommonException(ErrorCode.DUPLICATE_USERNAME)
         );
 
+        /**
+         * 탈퇴한 회원
+         */
+        if(findAccount.getDeletedType().equals(DeletedType.DELETE_YES)) {
+            throw new CustomCommonException(ErrorCode.UNREGISTER_USER);
+        }
+
         if(!passwordEncoder.matches(accountLoginRequestDto.getPassword(), findAccount.getPassword())){
             throw new CustomCommonException(ErrorCode.NOT_EQUAL_PASSWORD);
         }
@@ -72,7 +80,7 @@ public class AccountService {
          * 관리자 번호와 일치할 시 관리자 등급으로 변경
          */
         String adminSecretKey = accountLoginRequestDto.getAdminSecretKey();
-        if (hasAdminAuthroized(adminSecretKey)) {
+        if (hasAdminAuthorized(adminSecretKey)) {
             findAccount.upgradeAdmin();
             accountRepository.save(findAccount);
         }
@@ -87,8 +95,10 @@ public class AccountService {
             refreshTokenRepository.save(newRefreshToken);
         }
         System.out.println("tokenDto = " + tokenDto.getAccessToken());
+
         addTokenHeader(response, tokenDto);
 //        addTokenCookie(response, tokenDto);
+
         return new AccountLoginResponseDto(findAccount);
     }
 
@@ -99,7 +109,17 @@ public class AccountService {
         response.addCookie(cookie);
     }
 
-    private boolean hasAdminAuthroized(String adminSecretKey) {
+    @Transactional
+    public UnregisterUser unregister(Account account) {
+        Account findAccount = accountRepository.findByUsername(account.getUsername()).orElseThrow(
+                () -> new CustomCommonException(ErrorCode.USER_NOT_FOUND)
+        );
+        findAccount.deleteAccount();
+
+        return new UnregisterUser(findAccount.getUsername());
+    }
+
+    private boolean hasAdminAuthorized(String adminSecretKey) {
         return hasAdminSecretKey(adminSecretKey) && adminSecretKey.equals(ADMIN_SECRET_KEY);
     }
 

--- a/src/main/java/com/ono/omg/service/OrderService.java
+++ b/src/main/java/com/ono/omg/service/OrderService.java
@@ -5,9 +5,9 @@ import com.ono.omg.domain.Order;
 import com.ono.omg.domain.Product;
 import com.ono.omg.exception.CustomCommonException;
 import com.ono.omg.exception.ErrorCode;
+import com.ono.omg.repository.account.AccountRepository;
 import com.ono.omg.repository.order.OrderRepository;
 import com.ono.omg.repository.product.ProductRepository;
-import com.ono.omg.repository.account.AccountRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.slf4j.Logger;
@@ -17,7 +17,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
-import static com.ono.omg.dto.response.OrderResponseDto.*;
+import static com.ono.omg.dto.response.OrderResponseDto.CreatedOrdersResponseDto;
+import static com.ono.omg.dto.response.OrderResponseDto.cancelOrderResponseDto;
 
 @Service
 @Slf4j

--- a/src/main/java/com/ono/omg/utils/InitData.java
+++ b/src/main/java/com/ono/omg/utils/InitData.java
@@ -1,0 +1,32 @@
+package com.ono.omg.utils;
+
+import com.ono.omg.domain.Account;
+import com.ono.omg.domain.AccountType;
+import com.ono.omg.domain.DeletedType;
+import com.ono.omg.domain.Product;
+import com.ono.omg.repository.account.AccountRepository;
+import com.ono.omg.repository.order.OrderRepository;
+import com.ono.omg.repository.product.ProductRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Component;
+
+import javax.annotation.PostConstruct;
+
+@Component
+@RequiredArgsConstructor
+public class InitData {
+
+    private final AccountRepository accountRepository;
+    private final ProductRepository productRepository;
+
+    private final PasswordEncoder passwordEncoder;
+
+    @PostConstruct
+    public void init() {
+        for (int i = 1; i <= 10; i++) {
+            accountRepository.save(new Account(AccountType.ROLE_STANDARD, "안" + i, passwordEncoder.encode("감난다"), DeletedType.DELETE_NO));
+            productRepository.save(new Product("피카츄" + i, 1000 + i, "포켓몬", "초고속 배송", 15 + i, (long) i));
+        }
+    }
+}

--- a/src/main/java/com/ono/omg/utils/InitData.java
+++ b/src/main/java/com/ono/omg/utils/InitData.java
@@ -5,7 +5,6 @@ import com.ono.omg.domain.AccountType;
 import com.ono.omg.domain.DeletedType;
 import com.ono.omg.domain.Product;
 import com.ono.omg.repository.account.AccountRepository;
-import com.ono.omg.repository.order.OrderRepository;
 import com.ono.omg.repository.product.ProductRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;

--- a/src/main/resources/templates/admin/managedProducts.html
+++ b/src/main/resources/templates/admin/managedProducts.html
@@ -131,15 +131,6 @@
 
 <!--                <li class="page-item"><a class="page-link" href="#">Previous</a></li>-->
 <!--                <li class="page-item"><a class="page-link" href="#">1</a></li>-->
-<!--                <li class="page-item"><a class="page-link" href="#">2</a></li>-->
-<!--                <li class="page-item"><a class="page-link" href="#">3</a></li>-->
-<!--                <li class="page-item"><a class="page-link" href="#">4</a></li>-->
-<!--                <li class="page-item"><a class="page-link" href="#">5</a></li>-->
-<!--                <li class="page-item"><a class="page-link" href="#">6</a></li>-->
-<!--                <li class="page-item"><a class="page-link" href="#">7</a></li>-->
-<!--                <li class="page-item"><a class="page-link" href="#">8</a></li>-->
-<!--                <li class="page-item"><a class="page-link" href="#">9</a></li>-->
-<!--                <li class="page-item"><a class="page-link" href="#">10</a></li>-->
 <!--                <li class="page-item"><a class="page-link" href="#">Next</a></li>-->
             </ul>
         </nav>

--- a/src/test/java/com/ono/omg/redisson/RedissonLockStockFacadeTest.java
+++ b/src/test/java/com/ono/omg/redisson/RedissonLockStockFacadeTest.java
@@ -40,7 +40,7 @@ class RedissonLockStockFacadeTest {
     @BeforeEach
     public void insert() {
         productRepository.saveAndFlush(new Product("피카츄", 1000, "포켓몬", "초고속 배송", 1000, 1L));
-        accountRepository.saveAndFlush(new Account(1L, AccountType.ROLE_ADMIN, "이승우", "1234", DeletedType.DELETE_NO));
+//        accountRepository.saveAndFlush(new Account(AccountType.ROLE_ADMIN, "이승우", "1234", DeletedType.DELETE_NO));
 //        productRepository.saveAndFlush(new Product(101L, "라이츄", 1000, 1000, "포켓몬", "초고속 배송", 1L, "N", "king"));
 
 // =================================================== #
@@ -92,7 +92,7 @@ class RedissonLockStockFacadeTest {
         for (int i = 0; i < threadCount; i++) {
             executorService.submit(() -> {
                 try {
-                    orderController.CreatedOrder(1L, accountRepository.findByUsername("이승우").get());
+//                    orderController.CreatedOrder(1L, accountRepository.findByUsername("이승우").get());
                 } finally {
                     latch.countDown();
                 }

--- a/src/test/java/com/ono/omg/redisson/RedissonLockStockFacadeTest.java
+++ b/src/test/java/com/ono/omg/redisson/RedissonLockStockFacadeTest.java
@@ -1,5 +1,6 @@
 package com.ono.omg.redisson;
 
+import com.ono.omg.controller.OrderController;
 import com.ono.omg.domain.*;
 import com.ono.omg.dto.request.AccountRequestDto;
 import com.ono.omg.repository.account.AccountRepository;
@@ -33,11 +34,14 @@ class RedissonLockStockFacadeTest {
     @Autowired
     private AccountRepository accountRepository;
 
+    @Autowired
+    OrderController orderController;
+
     @BeforeEach
     public void insert() {
-//        productRepository.saveAndFlush(new Product("피카츄", 1000, "포켓몬", "초고속 배송", 1000, 1L));
+        productRepository.saveAndFlush(new Product("피카츄", 1000, "포켓몬", "초고속 배송", 1000, 1L));
         accountRepository.saveAndFlush(new Account(1L, AccountType.ROLE_ADMIN, "이승우", "1234", DeletedType.DELETE_NO));
-        productRepository.saveAndFlush(new Product(202L, "라이츄", 1000, 1000, "포켓몬", "초고속 배송", 1L, "N", "king"));
+//        productRepository.saveAndFlush(new Product(101L, "라이츄", 1000, 1000, "포켓몬", "초고속 배송", 1L, "N", "king"));
 
 // =================================================== #
 //        accountRepository.saveAndFlush(new Account(1L, AccountType.ROLE_ADMIN, "이승우", "1234", DeletedType.DELETE_NO));
@@ -49,11 +53,11 @@ class RedissonLockStockFacadeTest {
     }
 
     // 검증에 상관없는 요소 (삭제 순서가 바뀌어도 관련이 없다)
-    @AfterEach
-    public void delete() {
-        productRepository.deleteAll();
-        accountRepository.deleteAll();
-    }
+//    @AfterEach
+//    public void delete() {
+//        productRepository.deleteAll();
+//        accountRepository.deleteAll();
+//    }
 
     @Test
     public void 동시에_100개의_요청() throws InterruptedException {
@@ -61,12 +65,34 @@ class RedissonLockStockFacadeTest {
         ExecutorService executorService = Executors.newFixedThreadPool(32);
         CountDownLatch latch = new CountDownLatch(threadCount);
 
-        System.out.println("========== 1 =========");
+        for (int i = 0; i < threadCount; i++) {
+            executorService.submit(() -> {
+                try {
+                    redissonLockStockFacade.decrease(1L, accountRepository.findByUsername("이승우").get());
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+        latch.await();
+
+        Product product = productRepository.findById(1L).orElseThrow();
+
+        System.out.println("product.getStock() = " + product.getStock());
+        // 1000 - (1000 * 1) = 0
+        assertEquals(10, product.getStock());
+    }
+
+    @Test
+    public void 동시에_100개의_요청2() throws InterruptedException {
+        int threadCount = 990;
+        ExecutorService executorService = Executors.newFixedThreadPool(32);
+        CountDownLatch latch = new CountDownLatch(threadCount);
 
         for (int i = 0; i < threadCount; i++) {
             executorService.submit(() -> {
                 try {
-                    redissonLockStockFacade.decrease(101L, accountRepository.findByUsername("이승우").get());
+                    orderController.CreatedOrder(1L, accountRepository.findByUsername("이승우").get());
                 } finally {
                     latch.countDown();
                 }
@@ -79,6 +105,6 @@ class RedissonLockStockFacadeTest {
 
         System.out.println("product.getStock() = " + product.getStock());
         // 1000 - (1000 * 1) = 0
-//        assertEquals(10, product.getStock());
+        assertEquals(10, product.getStock());
     }
 }


### PR DESCRIPTION
Feat: RedissonLockStockFacade
- 클래스 사용없이 주문 생성 기능 Controller -> Service 형태를 거치도록 리팩토링

Refactor: Order field change isDeleted to OrderType(Enum)
- 기존에 주문 필드에 있던 isDeleted를 OrderType으로 변경하고, 주문취소 주문완료 상품준비 배송시작 수령완료 의 상수를 갖도록 구현 완료
- TN 필드와 동일하게 주문 취소 시 주문 데이터를 삭제 시키는 것이 아닌 OrderType을 ORDER_CANCEL로 변경

Feat: Add Order Cancel
src/main/java/com/ono/omg/service/OrderService.java cancel 메서드에 달아놓은 주석을 읽어보고 좋은 의견이 있다면 코멘트 부탁드립니다.

Feat: Unregister Account
회원 탈퇴 기능 구현 완료

=====

모든 기능 테스트 및 검증 구현 완료했습니다.

1. 주문 등록을 했을 때 재고 차감되는 건 Postman에서 하나씩 줄여가면서 테스트했을 때 재고가 없을 경우 예외 처리되는 거 확인했습니다.
2. 주문 등록 관련해서 Redisson 도입 후 멀티쓰레드 환경에서 동시 요청을 보내도 정상작동하는 거 확인했습니다.