### PR TITLE
Performance: QueryDSL-JPA vs FullText Search vs FullText Search with Covering Index

### DIFF
--- a/src/main/java/com/ono/omg/dto/response/SearchResponseDto.java
+++ b/src/main/java/com/ono/omg/dto/response/SearchResponseDto.java
@@ -19,7 +19,6 @@ public class SearchResponseDto {
     private String imgUrl;
 
     @Builder
-    @QueryProjection
     public SearchResponseDto(Long productId, String title, Integer price, Integer stock, String category, String delivery, Long sellerId, String isDeleted, String imgUrl) {
         this.productId = productId;
         this.title = title;
@@ -30,5 +29,15 @@ public class SearchResponseDto {
         this.sellerId = sellerId;
         this.isDeleted = isDeleted;
         this.imgUrl = imgUrl;
+    }
+
+    @QueryProjection
+    public SearchResponseDto(Long productId, String title, Integer price, Integer stock, String category, String delivery) {
+        this.productId = productId;
+        this.title = title;
+        this.price = price;
+        this.stock = stock;
+        this.category = category;
+        this.delivery = delivery;
     }
 }

--- a/src/main/java/com/ono/omg/repository/product/ProductRepositoryImpl.java
+++ b/src/main/java/com/ono/omg/repository/product/ProductRepositoryImpl.java
@@ -65,10 +65,11 @@ public class ProductRepositoryImpl implements ProductRepositoryCustom {
                         product.price,
                         product.stock,
                         product.category,
-                        product.delivery,
-                        product.sellerId,
-                        product.isDeleted,
-                        product.imgUrl
+                        product.delivery
+//                        ,
+//                        product.sellerId,
+//                        product.isDeleted,
+//                        product.imgUrl
                         )
                 )
                 .from(product)
@@ -93,10 +94,11 @@ public class ProductRepositoryImpl implements ProductRepositoryCustom {
                                 product.price,
                                 product.stock,
                                 product.category,
-                                product.delivery,
-                                product.sellerId,
-                                product.isDeleted,
-                                product.imgUrl
+                                product.delivery
+//                        ,
+//                                product.sellerId,
+//                                product.isDeleted,
+//                                product.imgUrl
                         )
                 )
                 .from(product)
@@ -132,37 +134,27 @@ public class ProductRepositoryImpl implements ProductRepositoryCustom {
         }
 
         // 2) 1의 결과로 발생한 id로 실제 select절 조회
-        JPAQuery<SearchResponseDto> rstQuery = queryFactory
+        List<SearchResponseDto> results = queryFactory
                 .select(new QSearchResponseDto(
                                 product.id,
                                 product.title,
                                 product.price,
                                 product.stock,
                                 product.category,
-                                product.delivery,
-                                product.sellerId,
-                                product.isDeleted,
-                                product.imgUrl
+                                product.delivery
                         )
                 )
                 .from(product)
-                .where(product.id.in(ids));
-
-        List<Long> countIds = queryFactory
-                .select(product.id)
-                .from(product)
-                .where(titleMatch(requestDto.getTitle()))
-                .offset(pageable.getOffset())
-                .limit(50)
+                .where(product.id.in(ids))
                 .fetch();
 
         Long count = queryFactory
                 .select(product.count())
                 .from(product)
-                .where(product.id.in(countIds))
+                .where(product.id.in(ids))
                 .fetchFirst();
 
-        return new PageImpl<>(rstQuery.fetch(), pageable, count);
+        return new PageImpl<>(results, pageable, count);
     }
 
     private BooleanExpression titleMatch(String title) {
@@ -175,10 +167,7 @@ public class ProductRepositoryImpl implements ProductRepositoryCustom {
         return booleanTemplate.gt(0);
     }
 
-
     private BooleanExpression titleEq(String productTitle) {
         return StringUtils.hasText(productTitle) ? product.title.eq(productTitle) : null;
     }
-
-
 }

--- a/src/main/resources/templates/detail/detailProduct.html
+++ b/src/main/resources/templates/detail/detailProduct.html
@@ -218,7 +218,7 @@
 
     <div class="container">
         <div align="center">
-            <h1 class="title">ONO.COM</h1>
+            <h1 class="title">상품 상세</h1>
         </div>
     </div>
 

--- a/src/test/java/com/ono/omg/repository/ProductRepositoryTest.java
+++ b/src/test/java/com/ono/omg/repository/ProductRepositoryTest.java
@@ -50,23 +50,6 @@ class ProductRepositoryTest extends RepositoryTest {
     }
 
     @Test
-    @DisplayName("searchProduct 메서드는 상품명에 대해 검색하는데 일치하는 값이 존재한다.")
-    public void searchByProductName() throws Exception {
-        // given
-        findAllProductHasStock();
-
-        PageRequest pageable = PageRequest.ofSize(5);
-        SearchRequestDto givenProductName = new SearchRequestDto("항해1");
-
-        // when
-        Page<SearchResponseDto> searchProducts = productRepository.searchProduct(givenProductName, pageable);
-
-        // then
-        assertThat(searchProducts.getNumberOfElements()).isEqualTo(1);
-        assertThat(searchProducts.getContent().get(0).getTitle()).isEqualTo("항해1");
-    }
-
-    @Test
     @DisplayName("searchByProductNameButNull 메서드는 상품명에 대해 검색한다. 단, 일치하는 값은 없다.")
     public void searchByProductNameButNull() throws Exception {
         // given
@@ -99,15 +82,32 @@ class ProductRepositoryTest extends RepositoryTest {
     }
 
     @Test
-    @DisplayName("searchMySQLFullTextSearchWithMatch 메서드는 '스크'라는 키워드를 기준으로 검색한다. 385,608 건의 결과 ==> 44501ms")
+    @DisplayName("42699ms :: searchProduct 메서드는 상품명에 대해 검색하는데 일치하는 값이 존재한다. 단순 QueryDSL-JPA만 사용")
+    public void searchByProductName() throws Exception {
+        // given
+        // findAllProductHasStock();
+
+        String keyword = "스크";
+        PageRequest pageable = PageRequest.of(1, 10);
+        SearchRequestDto givenProductName = new SearchRequestDto(keyword);
+
+        // when
+        Page<SearchResponseDto> results = productRepository.searchProduct(givenProductName, pageable);
+
+        // then
+//        assertThat(searchProducts.getNumberOfElements()).isEqualTo(1);
+//        assertThat(searchProducts.getContent().get(0).getTitle()).isEqualTo("스크");
+
+        System.out.println("totalElements = " + results.getTotalElements());
+    }
+
+    @Test
+    @DisplayName("1112ms :: searchMySQLFullTextSearchWithMatch 메서드는 '스크'라는 키워드를 기준으로 검색한다.")
     public void searchMySQLFullTextSearchWithMatch() throws Exception {
         // given
         String keyword = "스크"; // 스크의 검색 대상은 마 '스크', 아이 '스크' 림, 데 '스크' 탑
         SearchRequestDto searchRequestDto = new SearchRequestDto(keyword);
-
-        // 전체 데이터의 양 17,400,000
-        PageRequest pageable = PageRequest.of(1, 10); // 20 건의 결과      ==> 1110ms
-//        PageRequest pageable = PageRequest.ofSize(10);        // 385,608 건의 결과 ==> 44501ms
+        PageRequest pageable = PageRequest.of(1, 10);
 
         Page<SearchResponseDto> results = productRepository.searchProductUsedFullTextSearch(searchRequestDto, pageable);
 
@@ -115,33 +115,14 @@ class ProductRepositoryTest extends RepositoryTest {
     }
 
     @Test
-    @DisplayName("searchMySQLFullTextSearchWithMatchAndRowLookup 메서드는 '스크'라는 키워드를 기준으로 검색한다. 커버링 인덱싱 도입")
+    @DisplayName("1086ms :: searchMySQLFullTextSearchWithMatchAndCoveringIndex 메서드는 '스크'라는 키워드를 기준으로 검색한다. 커버링 인덱싱 도입")
     public void searchMySQLFullTextSearchWithMatchAndCoveringIndex() throws Exception {
         // given
         String keyword = "스크"; // 스크의 검색 대상은 마 '스크', 아이 '스크' 림, 데 '스크' 탑
         SearchRequestDto searchRequestDto = new SearchRequestDto(keyword);
-
-        // 전체 데이터의 양 17,400,000
-        PageRequest pageable = PageRequest.of(1, 10); // 20 건의 결과      ==> 1110ms
-//        PageRequest pageable = PageRequest.ofSize(10);        // 385,608 건의 결과 ==> 44501ms
+        PageRequest pageable = PageRequest.of(1, 10);
 
         Page<SearchResponseDto> results = productRepository.searchProductUsedFullTextSearchAndCoveringIndex(searchRequestDto, pageable);
-
-        System.out.println("totalElements = " + results.getTotalElements());
-    }
-
-    @Test
-    @DisplayName("searchProduct 메서드는 상품명에 대해 검색하는데 일치하는 값이 존재한다.")
-    public void searchNot() throws Exception {
-        // given
-        String keyword = "스크"; // 스크의 검색 대상은 마 '스크', 아이 '스크' 림, 데 '스크' 탑
-        SearchRequestDto searchRequestDto = new SearchRequestDto(keyword);
-
-        // 전체 데이터의 양 17,400,000
-        PageRequest pageable = PageRequest.of(1, 10);
-//        PageRequest pageable = PageRequest.ofSize(10);
-
-        Page<SearchResponseDto> results = productRepository.searchProduct(searchRequestDto, pageable);
 
         System.out.println("totalElements = " + results.getTotalElements());
     }


### PR DESCRIPTION
QueryDSL-JPA: 42699ms
FullText Search: 1112ms
FullText Search with Covering Index: 1086ms